### PR TITLE
Added getFreshFrameAveraged

### DIFF
--- a/ofxMachineVisionLib/ofxMachineVisionLib.vcxproj
+++ b/ofxMachineVisionLib/ofxMachineVisionLib.vcxproj
@@ -55,18 +55,22 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="..\..\..\libs\openFrameworksCompiled\project\vs\openFrameworksDebug.props" />
+    <Import Project="..\..\ofxCvMin\ofxCvMinLib\ofxCvMin.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="..\..\..\libs\openFrameworksCompiled\project\vs\openFrameworksDebug64.props" />
+    <Import Project="..\..\ofxCvMin\ofxCvMinLib\ofxCvMin.props" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="..\..\..\libs\openFrameworksCompiled\project\vs\openFrameworksRelease.props" />
+    <Import Project="..\..\ofxCvMin\ofxCvMinLib\ofxCvMin.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="..\..\..\libs\openFrameworksCompiled\project\vs\openFrameworksRelease64.props" />
+    <Import Project="..\..\ofxCvMin\ofxCvMinLib\ofxCvMin.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">

--- a/src/ofxMachineVision/Grabber/Simple.h
+++ b/src/ofxMachineVision/Grabber/Simple.h
@@ -5,6 +5,7 @@
 
 #include "Base.h"
 #include "ofxMachineVision/Frame.h"
+#include "ofxCvMin.h"
 
 namespace ofxMachineVision {
 	namespace Grabber {
@@ -28,6 +29,7 @@ namespace ofxMachineVision {
 			Microseconds getLastTimestamp() const { return this->lastTimestamp; }
 			long getLastFrameIndex() const { return this->lastFrameIndex; }
 			shared_ptr<Frame> getFreshFrame(float timeoutSeconds = 5.0f);
+			shared_ptr<Frame> getFreshFrameAveraged(int numExposures = 1);
 
 			/**
 			 \name ofBaseUpdates


### PR DESCRIPTION
ofxMachineVision::Grabber::getFreshFrameAveraged takes a number of exposures using ofxMachineVision::Grabber::getFreshFrame and synthesizes an average exposure, thus reducing noise in the resulting frame (at the cost of ghosting in dynamic scenes).

See discussion here:
https://github.com/elliotwoods/ofxDigitalEmulsion/issues/70

Note that this implementation introduces a dependency on ofxCvMin for any project using ofxMachineVision; to create the average frame, I use a 16 bit per channel Cv::Mat as an accumulation buffer. I am not sure if that is acceptable. An alternative to using Cv for averaging exposures would be to use an Fbo as an accumulation buffer instead, but this could lead to GPU/driver specific issues (eg max texture size for huge grabbers?)